### PR TITLE
Create schema_based_on_diagram.sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ This repository includes files with plain SQL:
 
 👤 **Abby**
 
-- GitHub: [@githubhandle](https://github.com/githubhandle)
-- Twitter: [@twitterhandle](https://twitter.com/twitterhandle)
-- LinkedIn: [LinkedIn](https://linkedin.com/in/linkedinhandle)
+- GitHub: [@AbbyNyakara](https://github.com/AbbyNyakara)
+- Twitter: [@AbigaelNyakara](https://twitter.com/AbbyNyakara)
+- LinkedIn: [Abigael Nyakara](https://linkedin.com/in/AbbyNyakara)
 
 
 ## 🤝 Contributing

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # clinic_database
 Creating a database diagram and database 
+In this projected, a file named schema_based_on_diagram.sql was created and the database from the diagram created.
+
+
+## Getting Started
+
+This repository includes files with plain SQL:
+- schema_based_on_diagram.sql which was used to created from the ERD
+
+## Authors
+
+👤 **Cecilia Mukima**
+
+- GitHub: [@c3c1l1a](https://github.com/c3c1l1a/)
+- Twitter: [@cMukima](https://twitter.com/CMukima)
+- LinkedIn: [cecilia-wangui-mukima](https://linkedin.com/in/linkedinhandle)
+- Profile [c3cl1ia.github.io](https://c3c1l1a.github.io)
+
+👤 **Abby**
+
+- GitHub: [@githubhandle](https://github.com/githubhandle)
+- Twitter: [@twitterhandle](https://twitter.com/twitterhandle)
+- LinkedIn: [LinkedIn](https://linkedin.com/in/linkedinhandle)
+
+
+## 🤝 Contributing
+
+Contributions, issues, and feature requests are welcome!
+
+Feel free to check the [issues page](../../issues/).
+
+## Show your support
+
+Give a ⭐️ if you like this project!
+
+## Acknowledgments
+
+- Hat tip to anyone whose code was used
+- Inspiration
+- etc
+
+## 📝 License
+
+This project is [MIT](https://spdx.org/licenses/MIT.html) licensed.
+

--- a/schema_based_on_diagram.sql
+++ b/schema_based_on_diagram.sql
@@ -1,0 +1,123 @@
+SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';
+
+-- -----------------------------------------------------
+-- Schema clinic_database
+-- -----------------------------------------------------
+
+-- -----------------------------------------------------
+-- Schema clinic_database
+-- -----------------------------------------------------
+CREATE SCHEMA IF NOT EXISTS `clinic_database` DEFAULT CHARACTER SET utf8 ;
+USE `clinic_database` ;
+
+-- -----------------------------------------------------
+-- Table `clinic_database`.`patients`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `clinic_database`.`patients` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `name` VARCHAR(45) NOT NULL,
+  `date_of_birth` DATE NOT NULL,
+  PRIMARY KEY (`id`))
+ENGINE = InnoDB;
+
+
+-- -----------------------------------------------------
+-- Table `clinic_database`.`medical_histories`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `clinic_database`.`medical_histories` (
+  `id` INT NOT NULL,
+  `admitted_at` TIMESTAMP NOT NULL,
+  `patient_id` INT NOT NULL,
+  `status` VARCHAR(45) NOT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `fk_medical_histories_patients1_idx` (`patient_id` ASC) VISIBLE,
+  CONSTRAINT `fk_medical_histories_patients1`
+    FOREIGN KEY (`patient_id`)
+    REFERENCES `clinic_database`.`patients` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;
+
+
+-- -----------------------------------------------------
+-- Table `clinic_database`.`treatments`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `clinic_database`.`treatments` (
+  `id` INT NOT NULL,
+  `type` VARCHAR(45) NOT NULL,
+  `name` VARCHAR(45) NOT NULL,
+  PRIMARY KEY (`id`))
+ENGINE = InnoDB;
+
+
+-- -----------------------------------------------------
+-- Table `clinic_database`.`invoices`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `clinic_database`.`invoices` (
+  `id` INT NOT NULL,
+  `total_amount` DECIMAL NOT NULL,
+  `generated_at` TIMESTAMP NOT NULL,
+  `payed_at` TIMESTAMP NOT NULL,
+  `medical_history_id` INT NOT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `fk_invoices_medical_histories1_idx` (`medical_history_id` ASC) VISIBLE,
+  CONSTRAINT `fk_invoices_medical_histories1`
+    FOREIGN KEY (`medical_history_id`)
+    REFERENCES `clinic_database`.`medical_histories` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;
+
+
+-- -----------------------------------------------------
+-- Table `clinic_database`.`invoice_items`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `clinic_database`.`invoice_items` (
+  `id` INT NOT NULL,
+  `unit_price` DECIMAL NOT NULL,
+  `quantity` INT NOT NULL,
+  `total_price` DECIMAL NOT NULL,
+  `invoice_id` INT NOT NULL,
+  `treatment_id` INT NOT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `fk_invoice_items_invoices1_idx` (`invoice_id` ASC) VISIBLE,
+  INDEX `fk_invoice_items_treatments1_idx` (`treatment_id` ASC) VISIBLE,
+  CONSTRAINT `fk_invoice_items_invoices1`
+    FOREIGN KEY (`invoice_id`)
+    REFERENCES `clinic_database`.`invoices` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_invoice_items_treatments1`
+    FOREIGN KEY (`treatment_id`)
+    REFERENCES `clinic_database`.`treatments` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;
+
+
+-- -----------------------------------------------------
+-- Table `clinic_database`.`medical_histories_has_treatments`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `clinic_database`.`medical_histories_has_treatments` (
+  `medical_histories_id` INT NOT NULL,
+  `treatments_id` INT NOT NULL,
+  PRIMARY KEY (`medical_histories_id`, `treatments_id`),
+  INDEX `fk_medical_histories_has_treatments_treatments1_idx` (`treatments_id` ASC) VISIBLE,
+  CONSTRAINT `fk_medical_histories_has_treatments_medical_histories1`
+    FOREIGN KEY (`medical_histories_id`)
+    REFERENCES `clinic_database`.`medical_histories` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_medical_histories_has_treatments_treatments1`
+    FOREIGN KEY (`treatments_id`)
+    REFERENCES `clinic_database`.`treatments` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;
+
+
+SET SQL_MODE=@OLD_SQL_MODE;
+SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;


### PR DESCRIPTION
## Create Database from Entity Relationship Diagram

![image](https://user-images.githubusercontent.com/81410040/187435085-84490588-4858-4f8e-944e-00a4527639b2.png)

#### What was accomplished 
- Created a file named schema_based_on_diagram.sql and implemented the database from the diagram.
- Join tables from many-to-many relationships might not appear in the diagram, but you still need them.
- Remember to add the FK indexes.


## Type of change
- Beta release

## Checklist
-    [Linting tests](https://github.com/microverseinc/linters-config) pass locally with my changes
-    Used correct [GitHub flow](https://github.com/microverseinc/curriculum-transversal-skills/blob/main/git-github/articles/github_flow.md)
-    Documentation is done in a [professional way](https://github.com/microverseinc/curriculum-transversal-skills/blob/main/documentation/articles/professional_repo_rules.md)